### PR TITLE
[RFC] experiment - can we pull out the header detail from the generated article?

### DIFF
--- a/src/article/article.test.ts
+++ b/src/article/article.test.ts
@@ -4,12 +4,49 @@ import { JSDOM } from 'jsdom';
 const validArticleHtml = `
   <article>
     <h1 itemprop="headline" content="Article">Article</h1>
+    <ol data-itemprop="authors">
+      <li itemscope="" itemtype="http://schema.org/Person" itemprop="author">
+        <meta itemprop="name" content="Dr Reece Urcher">
+        <span data-itemprop="givenNames">
+          <span itemprop="givenName">Reece</span>
+        </span>
+        <span data-itemprop="familyNames">
+          <span itemprop="familyName">Urcher</span>
+        </span>
+        <span data-itemprop="affiliations">
+          <a itemprop="affiliation" href="#author-organization-1">1</a>
+        </span>
+      </li>
+    </ol>
+    <ol data-itemprop="affiliations">
+      <li itemscope="" itemtype="http://schema.org/Organization" itemid="#author-organization-1" id="author-organization-1">
+        <span itemprop="name">Department of Neuroscience, The University of Texas at Austin</span>
+      </li>
+    </ol>
+    <span itemscope="" itemtype="http://schema.org/Organization" itemprop="publisher">
+      <meta itemprop="name" content="Unknown">
+      <span itemscope="" itemtype="http://schema.org/ImageObject" itemprop="logo">
+        <meta itemprop="url" content="https://via.placeholder.com/600x60/dbdbdb/4a4a4a.png?text=Unknown">
+      </span>
+    </span>
+    <time itemprop="datePublished" datetime="2021-07-06">2021-07-06</time>
+    <ul data-itemprop="about">
+      <li itemscope="" itemtype="http://schema.org/DefinedTerm" itemprop="about">
+        <span itemprop="name">New Results</span>
+      </li>
+    </ul>
+    <ul data-itemprop="identifiers">
+      <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+        <meta itemprop="propertyID" content="https://registry.identifiers.org/registry/doi">
+        <span itemprop="name">doi</span><span itemprop="value">12.345/67890213445</span>
+      </li>
+    </ul>
     <h2 itemscope="" itemtype="http://schema.stenci.la/Heading" id="s1">heading 1</h2>
     <h3 itemscope="" itemtype="http://schema.stenci.la/Heading" id="s1-1">subheading 1</h3>
     <h3 itemscope="" itemtype="http://schema.stenci.la/Heading" id="s1-2">subheading 2</h3>
     <h2 itemscope="" itemtype="http://schema.stenci.la/Heading" id="s2">heading 2</h2>
     <h2 itemscope="" itemtype="http://schema.stenci.la/Heading" id="s3">heading 3</h2>
-  </article>  
+  </article>
 `;
 
 const articleHtmlNoTitle = `
@@ -25,7 +62,7 @@ const articleHtmlNoTitle = `
 const articleHtmlNoHeadings = `
   <article>
     <h1 itemprop="headline" content="Article">Article</h1>
-  </article>  
+  </article>
 `;
 
 describe('article-page', () => {
@@ -47,6 +84,25 @@ describe('article-page', () => {
     const container = JSDOM.fragment(wrappedArticle);
 
     expect(container.querySelector('title')?.textContent).toBe('');
+  });
+
+  it('moves the article heading elements out of the article body and into an article header', () => {
+    const wrappedArticle = wrapArticleInHtml(validArticleHtml, '');
+    const container = JSDOM.fragment(wrappedArticle);
+
+    expect(container.querySelector('article > h1')).toBeNull()
+    expect(container.querySelector('article > [data-itemprop="authors"]')).toBeNull()
+    expect(container.querySelector('article > [data-itemprop="affiliations"]')).toBeNull()
+    expect(container.querySelector('article > [itemprop="publisher"]')).toBeNull()
+    expect(container.querySelector('article > [itemprop="datePublished"]')).toBeNull()
+    expect(container.querySelector('article > [data-itemprop="identifiers"]')).toBeNull()
+
+    expect(container.querySelector('main > .header > h1')?.textContent).toBe('Article');
+    expect(container.querySelector('main > .header > [data-itemprop="authors"]')?.textContent?.replaceAll(/[\s]{2,}/g,' ').trim()).toBe('Reece Urcher 1');
+    expect(container.querySelector('main > .header > [data-itemprop="affiliations"]')?.textContent?.replaceAll(/[\s]{2,}/g,' ').trim()).toBe('Department of Neuroscience, The University of Texas at Austin');
+    expect(container.querySelector('main > .header > [itemprop="publisher"]')?.textContent?.replaceAll(/[\s]{2,}/g,' ').trim()).toBe('');
+    expect(container.querySelector('main > .header > [itemprop="datePublished"]')?.textContent).toBe('2021-07-06');
+    expect(container.querySelector('main > .header > [data-itemprop="identifiers"]')?.textContent?.replaceAll(/[\s]{2,}/g,' ').trim()).toBe('doi12.345/67890213445');
   });
 
   it('does not include Table of Contents if no headings found', () => {

--- a/src/article/article.test.ts
+++ b/src/article/article.test.ts
@@ -5,7 +5,7 @@ const validArticleHtml = `
   <article>
     <h1 itemprop="headline" content="Article">Article</h1>
     <ol data-itemprop="authors">
-      <li itemscope="" itemtype="http://schema.org/Person" itemprop="author">
+      <li itemtype="http://schema.org/Person" itemprop="author">
         <meta itemprop="name" content="Dr Reece Urcher">
         <span data-itemprop="givenNames">
           <span itemprop="givenName">Reece</span>
@@ -19,43 +19,43 @@ const validArticleHtml = `
       </li>
     </ol>
     <ol data-itemprop="affiliations">
-      <li itemscope="" itemtype="http://schema.org/Organization" itemid="#author-organization-1" id="author-organization-1">
+      <li itemtype="http://schema.org/Organization" itemid="#author-organization-1" id="author-organization-1">
         <span itemprop="name">Department of Neuroscience, The University of Texas at Austin</span>
       </li>
     </ol>
-    <span itemscope="" itemtype="http://schema.org/Organization" itemprop="publisher">
+    <span itemtype="http://schema.org/Organization" itemprop="publisher">
       <meta itemprop="name" content="Unknown">
-      <span itemscope="" itemtype="http://schema.org/ImageObject" itemprop="logo">
+      <span itemtype="http://schema.org/ImageObject" itemprop="logo">
         <meta itemprop="url" content="https://via.placeholder.com/600x60/dbdbdb/4a4a4a.png?text=Unknown">
       </span>
     </span>
     <time itemprop="datePublished" datetime="2021-07-06">2021-07-06</time>
     <ul data-itemprop="about">
-      <li itemscope="" itemtype="http://schema.org/DefinedTerm" itemprop="about">
+      <li itemtype="http://schema.org/DefinedTerm" itemprop="about">
         <span itemprop="name">New Results</span>
       </li>
     </ul>
     <ul data-itemprop="identifiers">
-      <li itemscope="" itemtype="http://schema.org/PropertyValue" itemprop="identifier">
+      <li itemtype="http://schema.org/PropertyValue" itemprop="identifier">
         <meta itemprop="propertyID" content="https://registry.identifiers.org/registry/doi">
         <span itemprop="name">doi</span><span itemprop="value">12.345/67890213445</span>
       </li>
     </ul>
-    <h2 itemscope="" itemtype="http://schema.stenci.la/Heading" id="s1">heading 1</h2>
-    <h3 itemscope="" itemtype="http://schema.stenci.la/Heading" id="s1-1">subheading 1</h3>
-    <h3 itemscope="" itemtype="http://schema.stenci.la/Heading" id="s1-2">subheading 2</h3>
-    <h2 itemscope="" itemtype="http://schema.stenci.la/Heading" id="s2">heading 2</h2>
-    <h2 itemscope="" itemtype="http://schema.stenci.la/Heading" id="s3">heading 3</h2>
+    <h2 itemtype="http://schema.stenci.la/Heading" id="s1">heading 1</h2>
+    <h3 itemtype="http://schema.stenci.la/Heading" id="s1-1">subheading 1</h3>
+    <h3 itemtype="http://schema.stenci.la/Heading" id="s1-2">subheading 2</h3>
+    <h2 itemtype="http://schema.stenci.la/Heading" id="s2">heading 2</h2>
+    <h2 itemtype="http://schema.stenci.la/Heading" id="s3">heading 3</h2>
   </article>
 `;
 
 const articleHtmlNoTitle = `
   <article>
-    <h2 itemscope="" itemtype="http://schema.stenci.la/Heading" id="s1">heading 1</h2>
-    <h3 itemscope="" itemtype="http://schema.stenci.la/Heading" id="s1-1">subheading 1</h3>
-    <h3 itemscope="" itemtype="http://schema.stenci.la/Heading" id="s1-2">subheading 2</h3>
-    <h2 itemscope="" itemtype="http://schema.stenci.la/Heading" id="s2">heading 2</h2>
-    <h2 itemscope="" itemtype="http://schema.stenci.la/Heading" id="s3">heading 3</h2>
+    <h2 itemtype="http://schema.stenci.la/Heading" id="s1">heading 1</h2>
+    <h3 itemtype="http://schema.stenci.la/Heading" id="s1-1">subheading 1</h3>
+    <h3 itemtype="http://schema.stenci.la/Heading" id="s1-2">subheading 2</h3>
+    <h2 itemtype="http://schema.stenci.la/Heading" id="s2">heading 2</h2>
+    <h2 itemtype="http://schema.stenci.la/Heading" id="s3">heading 3</h2>
   </article>
 `
 

--- a/src/article/article.test.ts
+++ b/src/article/article.test.ts
@@ -51,11 +51,11 @@ const validArticleHtml = `
 
 const articleHtmlNoTitle = `
   <article>
-    <h2 itemtype="http://schema.stenci.la/Heading" id="s1">heading 1</h2>
-    <h3 itemtype="http://schema.stenci.la/Heading" id="s1-1">subheading 1</h3>
-    <h3 itemtype="http://schema.stenci.la/Heading" id="s1-2">subheading 2</h3>
-    <h2 itemtype="http://schema.stenci.la/Heading" id="s2">heading 2</h2>
-    <h2 itemtype="http://schema.stenci.la/Heading" id="s3">heading 3</h2>
+    <h2 itemscope="" itemtype="http://schema.stenci.la/Heading" id="s1">heading 1</h2>
+    <h3 itemscope="" itemtype="http://schema.stenci.la/Heading" id="s1-1">subheading 1</h3>
+    <h3 itemscope="" itemtype="http://schema.stenci.la/Heading" id="s1-2">subheading 2</h3>
+    <h2 itemscope="" itemtype="http://schema.stenci.la/Heading" id="s2">heading 2</h2>
+    <h2 itemscope="" itemtype="http://schema.stenci.la/Heading" id="s3">heading 3</h2>
   </article>
 `
 

--- a/src/article/article.test.ts
+++ b/src/article/article.test.ts
@@ -97,12 +97,12 @@ describe('article-page', () => {
     expect(container.querySelector('article > [itemprop="datePublished"]')).toBeNull()
     expect(container.querySelector('article > [data-itemprop="identifiers"]')).toBeNull()
 
-    expect(container.querySelector('main > .header > h1')?.textContent).toBe('Article');
-    expect(container.querySelector('main > .header > [data-itemprop="authors"]')?.textContent?.replaceAll(/[\s]{2,}/g,' ').trim()).toBe('Reece Urcher 1');
-    expect(container.querySelector('main > .header > [data-itemprop="affiliations"]')?.textContent?.replaceAll(/[\s]{2,}/g,' ').trim()).toBe('Department of Neuroscience, The University of Texas at Austin');
-    expect(container.querySelector('main > .header > [itemprop="publisher"]')?.textContent?.replaceAll(/[\s]{2,}/g,' ').trim()).toBe('');
-    expect(container.querySelector('main > .header > [itemprop="datePublished"]')?.textContent).toBe('2021-07-06');
-    expect(container.querySelector('main > .header > [data-itemprop="identifiers"]')?.textContent?.replaceAll(/[\s]{2,}/g,' ').trim()).toBe('doi12.345/67890213445');
+    expect(container.querySelector('.content-header > h1')?.textContent).toBe('Article');
+    expect(container.querySelector('.content-header > [data-itemprop="authors"]')?.textContent?.replaceAll(/[\s]{2,}/g,' ').trim()).toBe('Reece Urcher 1');
+    expect(container.querySelector('.content-header > [data-itemprop="affiliations"]')?.textContent?.replaceAll(/[\s]{2,}/g,' ').trim()).toBe('Department of Neuroscience, The University of Texas at Austin');
+    expect(container.querySelector('.content-header > [itemprop="publisher"]')?.textContent?.replaceAll(/[\s]{2,}/g,' ').trim()).toBe('');
+    expect(container.querySelector('.content-header > [itemprop="datePublished"]')?.textContent).toBe('2021-07-06');
+    expect(container.querySelector('.content-header > [data-itemprop="identifiers"]')?.textContent?.replaceAll(/[\s]{2,}/g,' ').trim()).toBe('doi12.345/67890213445');
   });
 
   it('does not include Table of Contents if no headings found', () => {

--- a/src/article/article.ts
+++ b/src/article/article.ts
@@ -110,7 +110,7 @@ const getArticleHtmlWithoutHeader = (articleDom: DocumentFragment): string => {
   const articleElement = articleDom.children[0];
   console.log(articleElement.outerHTML);
 
-  var articleHtml = "";
+  let articleHtml = "";
   articleElement.querySelectorAll('[data-itemprop="identifiers"] ~ *').forEach((elem) => articleHtml += elem.outerHTML);
 
   return `<article itemscope="" itemtype="http://schema.org/Article" data-itemscope="root">${articleHtml}</article>`;

--- a/src/article/article.ts
+++ b/src/article/article.ts
@@ -4,6 +4,8 @@ export const wrapArticleInHtml = (articleHTML: string, doi: string): string => {
   const articleFragment = JSDOM.fragment(articleHTML);
   const title = getTitle(articleFragment);
   const headings = getHeadings(articleFragment);
+  const header = getHeader(articleFragment);
+  const articleHtmlWithoutHeader = getArticleHtmlWithoutHeader(articleFragment);
   return `
 <html lang="en">
   <head>
@@ -19,7 +21,7 @@ export const wrapArticleInHtml = (articleHTML: string, doi: string): string => {
   <body>
     <div class="grid-container">
       <div class="content-header">
-        Content Header
+        ${header}
       </div>
 
       <div class="secondary-column">
@@ -84,4 +86,32 @@ const getHeadings = (articleDom: DocumentFragment): Heading[] => {
     }
     return headings;
   }, new Array<Heading>());
+}
+
+const getHeader = (articleDom: DocumentFragment): string => {
+  const headline = articleDom.querySelector('article > [itemprop="headline"]');
+  const authors = articleDom.querySelector('article > [data-itemprop="authors"]');
+  const affiliations = articleDom.querySelector('article > [data-itemprop="affiliations"]');
+  const publisher = articleDom.querySelector('article > [itemprop="publisher"]');
+  const datePublished = articleDom.querySelector('article > [itemprop="datePublished"]');
+  const identifiers = articleDom.querySelector('article > [data-itemprop="identifiers"]');
+
+  return `<div class="header">
+    ${headline?.outerHTML}
+    ${authors?.outerHTML}
+    ${affiliations?.outerHTML}
+    ${publisher?.outerHTML}
+    ${datePublished?.outerHTML}
+    ${identifiers?.outerHTML}
+  </div>`;
+}
+
+const getArticleHtmlWithoutHeader = (articleDom: DocumentFragment): string => {
+  const articleElement = articleDom.children[0];
+  console.log(articleElement.outerHTML);
+
+  var articleHtml = "";
+  articleElement.querySelectorAll('[data-itemprop="identifiers"] ~ *').forEach((elem) => articleHtml += elem.outerHTML);
+
+  return `<article itemscope="" itemtype="http://schema.org/Article" data-itemscope="root">${articleHtml}</article>`;
 }

--- a/src/article/article.ts
+++ b/src/article/article.ts
@@ -20,10 +20,7 @@ export const wrapArticleInHtml = (articleHTML: string, doi: string): string => {
   </head>
   <body>
     <div class="grid-container">
-      <div class="content-header">
-        ${header}
-      </div>
-
+      ${header}
       <div class="secondary-column">
         <div class="review-link__container">
           <a class="review-link__anchor" href="/article/${doi}/reviews">Reviews ></a>
@@ -35,7 +32,7 @@ export const wrapArticleInHtml = (articleHTML: string, doi: string): string => {
           ${generateToC(headings)}
         </div>
         <div class="main-content-area">
-          ${articleHTML}
+          ${articleHtmlWithoutHeader}
         </div>
       </main>
     </div>
@@ -96,7 +93,7 @@ const getHeader = (articleDom: DocumentFragment): string => {
   const datePublished = articleDom.querySelector('article > [itemprop="datePublished"]');
   const identifiers = articleDom.querySelector('article > [data-itemprop="identifiers"]');
 
-  return `<div class="header">
+  return `<div itemtype="http://schema.org/Article" class="content-header" data-itemscope="root">
     ${headline?.outerHTML}
     ${authors?.outerHTML}
     ${affiliations?.outerHTML}

--- a/src/article/article.ts
+++ b/src/article/article.ts
@@ -105,10 +105,9 @@ const getHeader = (articleDom: DocumentFragment): string => {
 
 const getArticleHtmlWithoutHeader = (articleDom: DocumentFragment): string => {
   const articleElement = articleDom.children[0];
-  console.log(articleElement.outerHTML);
 
-  let articleHtml = "";
-  articleElement.querySelectorAll('[data-itemprop="identifiers"] ~ *').forEach((elem) => articleHtml += elem.outerHTML);
+  const articleHtml = Array.from(articleElement.querySelectorAll('[data-itemprop="identifiers"] ~ *'))
+    .reduce((prev, current) => prev.concat(current.outerHTML), '');
 
   return `<article itemtype="http://schema.org/Article">${articleHtml}</article>`;
 }

--- a/src/article/article.ts
+++ b/src/article/article.ts
@@ -113,5 +113,5 @@ const getArticleHtmlWithoutHeader = (articleDom: DocumentFragment): string => {
   let articleHtml = "";
   articleElement.querySelectorAll('[data-itemprop="identifiers"] ~ *').forEach((elem) => articleHtml += elem.outerHTML);
 
-  return `<article itemscope="" itemtype="http://schema.org/Article" data-itemscope="root">${articleHtml}</article>`;
+  return `<article itemtype="http://schema.org/Article">${articleHtml}</article>`;
 }

--- a/src/article/index.scss
+++ b/src/article/index.scss
@@ -6,6 +6,7 @@ img {
 }
 
 .content-header {
+  grid-column: 1/10;
   margin: 0;
   text-align: left;
 }

--- a/src/article/index.scss
+++ b/src/article/index.scss
@@ -6,7 +6,6 @@ img {
 }
 
 .content-header {
-  grid-column: 1/10;
   margin: 0;
   text-align: left;
 }


### PR DESCRIPTION
Experiment using JSDom, pull out the "header" items, and then generate a new article element without them there.
This may allow quickly experimenting with moving these head things elsewhere on the page.

# Tasks before ready for merging

- [x] Write a test for new header behaviour
- [x] Review wrapping HTML elements