### PR TITLE
Change to Google font CDN - cool labs isn't working correctly

### DIFF
--- a/src/base-page/base-page.ts
+++ b/src/base-page/base-page.ts
@@ -5,8 +5,7 @@ export const basePage = (pageContent: string): string =>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta http-equiv="X-UA-Compatible" content="ie=edge">
-        <link href="https://api.fonts.coollabs.io/css2?family=Noto+Sans" rel="stylesheet"/>
-        <link href="https://api.fonts.coollabs.io/css2?family=Noto+Serif" rel="stylesheet"/>
+        <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;600&family=Noto+Serif" rel="stylesheet">
         <link rel="stylesheet" href="/styles.css"/>
       </head>
       <body>


### PR DESCRIPTION
We're not currently pulling in a weight 600 font for Noto Sans, despite using it in the typography.

Unfortunately, when asking for weight 6000 from the coollabs css2 api, it gives a font file that is status 400:
https://cdn.fonts.coollabs.io/noto-sans/normal/600.woff2

Switched back to google fonts