### PR TITLE
Switch settings around to default to eLife Branding

### DIFF
--- a/src/sass/_settings.scss
+++ b/src/sass/_settings.scss
@@ -6,7 +6,7 @@ $color-less-light-grey: rgb(237, 239, 244);
 $color-divider-grey: #E0E0E0;
 
 
-$color-emphasis: rgb(188,35,37); // red
+$color-emphasis: rgb(8,122,204); // "accessible blue"
 
 // Fonts
 $font-family-primary: Noto Sans,Arial,Helvetica,sans-serif;
@@ -17,7 +17,13 @@ $max-site-width: 1296px;
 $grid-column: 78px;
 $grid-gutter: 24px;
 
-$logo-url: url(https://static.wixstatic.com/media/1f1e58_cde9872c8ecf470d8f8238a81a1d4f1b~mv2.png/v1/fill/w_492,h_192,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/210628_Biophysics%20Logo_FINAL%202.png);
+// biophysics-colab
+// $logo-url: url(https://static.wixstatic.com/media/1f1e58_cde9872c8ecf470d8f8238a81a1d4f1b~mv2.png/v1/fill/w_492,h_192,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/210628_Biophysics%20Logo_FINAL%202.png);
+// $color-emphasis: rgb(188,35,37); // "biophysics red"
+
+// elife
+$logo-url: url(https://elifesciences.org/assets/patterns/img/patterns/organisms/elife-logo-xs.fd623d00.svg);
+$color-emphasis: rgb(8,122,204); // "accessible blue"
 
 // Logo
 @mixin logo-img {


### PR DESCRIPTION
Due to the shifting focus of the prototype being used to validate value of preprint enhancement features, eLife branding is preferred in the short-term until we're building features "for real".

This is just changing the emphasis colour and the logo for now to eLife, while keeping the biophysics-colab ones around until we have a runtime/deploy time switching mechanism

closes #65 