### PR TITLE
Fix crash on non-existent docmap

### DIFF
--- a/src/reviews/fetch-reviews.test.ts
+++ b/src/reviews/fetch-reviews.test.ts
@@ -37,4 +37,9 @@ describe('fetch-reviews', () => {
     expect(mockedGet).toHaveBeenNthCalledWith(3, expect.stringContaining('A2ZbGBCxEeyu-CsIpygfMQ'));
     expect(mockedGet).toHaveBeenNthCalledWith(4, expect.stringContaining('J2qSChC1EeyvHS8fi9T9oQ'));
   });
+
+  describe('when unable to retrieve the docmap', () => {
+    it.todo('returns empty array on http errors');
+    it.todo('returns empty array if there are no hypothesis link in the docmap');
+  })
 });

--- a/src/reviews/fetch-reviews.test.ts
+++ b/src/reviews/fetch-reviews.test.ts
@@ -1,7 +1,7 @@
 import { fetchReviews, HypothesisResponse } from './fetch-reviews';
 import axios from 'axios';
 import { mocked } from 'jest-mock';
-import { docmapMock } from "../../test-utils/docmap-mock";
+import { docmapMock, docmapNoHypothesisMock } from "../../test-utils/docmap-mock";
 
 jest.mock('axios');
 
@@ -39,7 +39,26 @@ describe('fetch-reviews', () => {
   });
 
   describe('when unable to retrieve the docmap', () => {
-    it.todo('returns empty array on http errors');
-    it.todo('returns empty array if there are no hypothesis link in the docmap');
+    it('returns empty array on http errors', async () => {
+      const mockedGet = mocked(axios.get, true);
+      mockedGet.mockImplementation(() => Promise.reject({
+        data: {},
+        status: 404,
+      }));
+      const reviews = await fetchReviews('10.1101/2021.07.05.451181', 'https://biophysics.sciencecolab.org');
+
+      expect(reviews).toStrictEqual([]);
+    });
+
+    it('returns empty array if there are no hypothesis link in the docmap', async () => {
+      const mockedGet = mocked(axios.get, true);
+      mockedGet.mockImplementation(() => Promise.resolve({
+        data: docmapNoHypothesisMock,
+        status: 200,
+      }));
+      const reviews = await fetchReviews('10.1101/2021.07.05.451181', 'https://biophysics.sciencecolab.org');
+
+      expect(reviews).toStrictEqual([]);
+    });
   })
 });

--- a/src/reviews/fetch-reviews.ts
+++ b/src/reviews/fetch-reviews.ts
@@ -9,7 +9,8 @@ export const fetchReviews: FetchReviews = async (doi, reviewingGroup) => {
   const docmaps = await fetchDocmaps(doi);
   const docmap = docmaps.find(docmap => docmap.publisher.id === reviewingGroup);
   if (!docmap) {
-    return Promise.reject(`No docmap for reviewingGroup: ${reviewingGroup} and doi: ${doi}`);
+    console.warn(`No docmap for reviewingGroup: ${reviewingGroup} and doi: ${doi}`)
+    return Promise.resolve([]);
   }
   const hypothesisUrls = Object.values(docmap.steps)
     .flatMap(docmapStep => docmapStep.actions
@@ -21,6 +22,10 @@ export const fetchReviews: FetchReviews = async (doi, reviewingGroup) => {
       )
     );
 
+  if (!hypothesisUrls.length) {
+    console.warn(`No hypothesis urls found in docmap for reviewingGroup: ${reviewingGroup} and doi: ${doi}`);
+    return Promise.resolve([]);
+  }
   const hypothesisIds = hypothesisUrls.map(url => {
     const urlParts = url.split('/');
     return urlParts[urlParts.length -1];

--- a/src/reviews/fetch-reviews.ts
+++ b/src/reviews/fetch-reviews.ts
@@ -38,7 +38,7 @@ export const fetchReviews: FetchReviews = async (doi, reviewingGroup) => {
 
 type FetchDocmap = (doi: string) => Promise<Array<Docmap>>;
 const fetchDocmaps: FetchDocmap = async (doi) => {
-  return axios.get<Array<Docmap>>(`https://sciety.org/docmaps/v1/articles/${doi}.docmap.json`).then(async (response) => response.data);
+  return axios.get<Array<Docmap>>(`https://sciety.org/docmaps/v1/articles/${doi}.docmap.json`).then(async (response) => response.data).catch(() => []);
 }
 
 type DocmapStep = {

--- a/src/reviews/fetch-reviews.ts
+++ b/src/reviews/fetch-reviews.ts
@@ -9,7 +9,6 @@ export const fetchReviews: FetchReviews = async (doi, reviewingGroup) => {
   const docmaps = await fetchDocmaps(doi);
   const docmap = docmaps.find(docmap => docmap.publisher.id === reviewingGroup);
   if (!docmap) {
-    console.warn(`No docmap for reviewingGroup: ${reviewingGroup} and doi: ${doi}`)
     return Promise.resolve([]);
   }
   const hypothesisUrls = Object.values(docmap.steps)
@@ -23,7 +22,6 @@ export const fetchReviews: FetchReviews = async (doi, reviewingGroup) => {
     );
 
   if (!hypothesisUrls.length) {
-    console.warn(`No hypothesis urls found in docmap for reviewingGroup: ${reviewingGroup} and doi: ${doi}`);
     return Promise.resolve([]);
   }
   const hypothesisIds = hypothesisUrls.map(url => {

--- a/src/reviews/reviews.ts
+++ b/src/reviews/reviews.ts
@@ -1,6 +1,9 @@
 import { marked } from "marked";
 
 export const generateReviewPage = (reviews: string[], doi: string): string => {
+  if (reviews.length == 0) {
+    return wrapWithHtml(`<li class="review-list__item"><article class="review-list-content">No reviews found</article></li>`, doi);
+  }
   const reviewListItems = reviews.map(review => `<li class="review-list__item"><article class="review-list-content">${marked.parse(review)}</article></li>`)
   return wrapWithHtml(reviewListItems.join(''), doi);
 }

--- a/src/reviews/reviews.ts
+++ b/src/reviews/reviews.ts
@@ -2,7 +2,7 @@ import { marked } from "marked";
 
 export const generateReviewPage = (reviews: string[], doi: string): string => {
   if (reviews.length == 0) {
-    return wrapWithHtml(`<li class="review-list__item"><article class="review-list-content">No reviews found</article></li>`, doi);
+    return wrapWithHtml('<li class="review-list__item"><article class="review-list-content">No reviews found</article></li>', doi);
   }
   const reviewListItems = reviews.map(review => `<li class="review-list__item"><article class="review-list-content">${marked.parse(review)}</article></li>`)
   return wrapWithHtml(reviewListItems.join(''), doi);

--- a/src/reviews/reviews.ts
+++ b/src/reviews/reviews.ts
@@ -1,6 +1,8 @@
 import { marked } from "marked";
+import { fetchReviews } from "./fetch-reviews";
 
-export const generateReviewPage = (reviews: string[], doi: string): string => {
+export const generateReviewPage = async (doi: string): Promise<string> => {
+  const reviews = await fetchReviews(doi, 'https://biophysics.sciencecolab.org')
   if (reviews.length == 0) {
     return wrapWithHtml('<li class="review-list__item"><article class="review-list-content">No reviews found</article></li>', doi);
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,6 @@ import { readdirSync } from "fs";
 import { convertJatsToHtml } from "./conversion/encode";
 import { generateArticleList } from "./article-list/article-list";
 import { buildArticlePage } from "./article/article";
-import { fetchReviews } from "./reviews/fetch-reviews";
 import { generateReviewPage } from "./reviews/reviews";
 import { basePage } from "./base-page/base-page";
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -43,7 +43,7 @@ app.get('/article/:journalId/:articleId', async (req, res) => {
 app.get('/article/:journalId/:articleId/reviews', async (req, res) => {
   const { journalId, articleId } = req.params;
   const doi = `${journalId}/${articleId}`;
-  const reviews = await fetchReviews(doi, 'https://biophysics.sciencecolab.org').catch(() => ["No reviews found"]);
+  const reviews = await fetchReviews(doi, 'https://biophysics.sciencecolab.org').catch(() => []);
   res.send(basePage(generateReviewPage(reviews, doi)));
 });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -43,8 +43,7 @@ app.get('/article/:journalId/:articleId', async (req, res) => {
 app.get('/article/:journalId/:articleId/reviews', async (req, res) => {
   const { journalId, articleId } = req.params;
   const doi = `${journalId}/${articleId}`;
-  const reviews = await fetchReviews(doi, 'https://biophysics.sciencecolab.org').catch(() => []);
-  res.send(basePage(generateReviewPage(reviews, doi)));
+  res.send(basePage(await generateReviewPage(doi)));
 });
 
 app.listen(3000, () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -43,7 +43,7 @@ app.get('/article/:journalId/:articleId', async (req, res) => {
 app.get('/article/:journalId/:articleId/reviews', async (req, res) => {
   const { journalId, articleId } = req.params;
   const doi = `${journalId}/${articleId}`;
-  const reviews = await fetchReviews(doi, 'https://biophysics.sciencecolab.org');
+  const reviews = await fetchReviews(doi, 'https://biophysics.sciencecolab.org').catch(() => ["No reviews found"]);
   res.send(basePage(generateReviewPage(reviews, doi)));
 });
 

--- a/test-utils/docmap-mock.ts
+++ b/test-utils/docmap-mock.ts
@@ -112,3 +112,118 @@ export const docmapMock = [
     }
   }
 ];
+
+export const docmapNoHypothesisMock = [
+  {
+    "@context": "https://w3id.org/docmaps/context.jsonld",
+    "id": "https://sciety.org/docmaps/v1/articles/10.1101/2021.07.05.451181/biophysics-colab.docmap.json",
+    "type": "docmap",
+    "created": "2021-09-08T15:06:52.000Z",
+    "updated": "2021-09-08T15:06:52.000Z",
+    "publisher": {
+      "id": "https://biophysics.sciencecolab.org",
+      "name": "Biophysics Colab",
+      "logo": "https://sciety.org/static/groups/biophysics-colab--4bbf0c12-629b-4bb8-91d6-974f4df8efb2.png",
+      "homepage": "https://biophysics.sciencecolab.org",
+      "account": {
+        "id": "https://sciety.org/groups/biophysics-colab",
+        "service": "https://sciety.org"
+      }
+    },
+    "first-step": "_:b0",
+    "steps": {
+      "_:b0": {
+        "assertions": [],
+        "inputs": [
+          {
+            "doi": "10.1101/2021.07.05.451181",
+            "url": "https://doi.org/10.1101/2021.07.05.451181"
+          }
+        ],
+        "actions": [
+          {
+            "participants": [
+              {
+                "actor": {
+                  "name": "anonymous",
+                  "type": "person"
+                },
+                "role": "peer-reviewer"
+              }
+            ],
+            "outputs": [
+              {
+                "type": "review-article",
+                "published": "2021-09-08T14:51:35.722Z",
+                "content": [
+                  {
+                    "type": "web-page",
+                    "url": "https://www.elifesciences.org"
+                  },
+                  {
+                    "type": "web-page",
+                    "url": "https://sciety.org/articles/activity/10.1101/2021.07.05.451181#hypothesis:Q9GJ9BC0EeyPVBtgAn5Yjw"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "participants": [
+              {
+                "actor": {
+                  "name": "anonymous",
+                  "type": "person"
+                },
+                "role": "peer-reviewer"
+              }
+            ],
+            "outputs": [
+              {
+                "type": "review-article",
+                "published": "2021-09-08T14:28:19.243Z",
+                "content": [
+                  {
+                    "type": "web-page",
+                    "url": "https://www.elifesciences.org"
+                  },
+                  {
+                    "type": "web-page",
+                    "url": "https://sciety.org/articles/activity/10.1101/2021.07.05.451181#hypothesis:A2ZbGBCxEeyu-CsIpygfMQ"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "participants": [
+              {
+                "actor": {
+                  "name": "anonymous",
+                  "type": "person"
+                },
+                "role": "peer-reviewer"
+              }
+            ],
+            "outputs": [
+              {
+                "type": "review-article",
+                "published": "2021-09-08T14:57:57.652Z",
+                "content": [
+                  {
+                    "type": "web-page",
+                    "url": "https://www.elifesciences.org"
+                  },
+                  {
+                    "type": "web-page",
+                    "url": "https://sciety.org/articles/activity/10.1101/2021.07.05.451181#hypothesis:J2qSChC1EeyvHS8fi9T9oQ"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+];


### PR DESCRIPTION
@will-byrne I'm interested to know how to improve on this? 

My thinking is this: 
- Returning an empty array on failure means the logic finding a matching docmap for the `reviewingGroup` will fail, rejecting the `fetchReviews` Promise. 
- Further, if `fetchReviews()` is a rejected promise, we should display ***something***, I've chosen to return a blank array, and alter generateReviewPage to say the reviews we not found.
- 
This allows us to close #58, but feels a bit icky:
 - any HTTP failure will now return a failed Promise saying "No docmap for ...", which isn't true in the case of temporary server failure or timeout. 
 - Actually, all rejected promises of `fetchReviews` are treated as if there are no reviews.

I'm not familiar enough with async error handling to know a better way of signalling a 404 = no reviews, other status = Error, and how to handle that in the upper layers. Feels worth a pairing session to me.

Closes #58 