### PR TITLE
stop the array being rendered to comma-separated string 

### DIFF
--- a/src/article-list/article-list.ts
+++ b/src/article-list/article-list.ts
@@ -5,7 +5,7 @@ export const generateArticleList = (journals: string[], articles: Record<string,
       ${journals.map(journal => `
       <h2 class="articles-list__heading">${journal}</h2>
       <ul class="articles-list">
-          ${articles[journal].map(article => `<li><a class="article-list__link" href="/article/${journal}/${article}">${article}</a></li>`)}
+          ${articles[journal].map(article => `<li><a class="article-list__link" href="/article/${journal}/${article}">${article}</a></li>`).join('')}
       </ul>
       `).join('')}
     </div>


### PR DESCRIPTION
Example:
<img width="194" alt="Screenshot 2022-05-11 at 4 10 06 pm" src="https://user-images.githubusercontent.com/375812/167884500-d863f4db-f023-4a60-b0af-4b16b1cfea9b.png">


Fix by joining with an empty string in the template.