### PR TITLE
Environment settings and HTTP import

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,22 @@
+import { StoreType } from './model/create-article-repository';
+
+const getStoreTypeFromString = (repoType: string): StoreType => {
+  if (repoType === 'Sqlite') {
+    return StoreType.Sqlite;
+  }
+  if (repoType === 'InMemory') {
+    return StoreType.InMemory;
+  }
+
+  // eslint-disable-next-line no-console
+  console.log(`Cannot find article repository type of ${repoType}, defaulting to InMemory`);
+  return StoreType.InMemory;
+};
+
+export const config = {
+  id: process.env.REVIEWGROUP_ID ?? 'https://elifesciences.org',
+  name: process.env.REVIEWGROUP_NAME ?? 'eLife',
+  dataDir: process.env.IMPORT_DIR_PATH ?? './data/10.1101',
+  repoType: process.env.REPO_TYPE ? getStoreTypeFromString(process.env.REPO_TYPE) : StoreType.Sqlite,
+  repoConnection: process.env.REPO_CONNECTION ?? './data.db',
+};

--- a/src/data-loader/data-loader.ts
+++ b/src/data-loader/data-loader.ts
@@ -44,7 +44,7 @@ const processArticle = async (file: PreprintXmlFile): Promise<ArticleContent> =>
   };
 };
 
-export const loadXmlArticlesFromDirIntoStores = (dataDir: string, articleRepository: ArticleRepository) => {
+export const loadXmlArticlesFromDirIntoStores = (dataDir: string, articleRepository: ArticleRepository): Promise<boolean[]> => {
   const xmlFiles = getDirectories(dataDir).map((articleId) => `${dataDir}/${articleId}/${articleId}.xml`).filter((xmlFilePath) => existsSync(xmlFilePath));
 
   return Promise.all(xmlFiles.map((xmlFile) => processArticle(xmlFile).then((articleContent) => articleRepository.storeArticle(articleContent))));

--- a/src/data-loader/data-loader.ts
+++ b/src/data-loader/data-loader.ts
@@ -44,7 +44,7 @@ const processArticle = async (file: PreprintXmlFile): Promise<ArticleContent> =>
   };
 };
 
-export const loadXmlArticlesFromDirIntoStores = async (dataDir: string, articleRepository: ArticleRepository) => {
+export const loadXmlArticlesFromDirIntoStores = (dataDir: string, articleRepository: ArticleRepository) => {
   const xmlFiles = getDirectories(dataDir).map((articleId) => `${dataDir}/${articleId}/${articleId}.xml`).filter((xmlFilePath) => existsSync(xmlFilePath));
 
   return Promise.all(xmlFiles.map((xmlFile) => processArticle(xmlFile).then((articleContent) => articleRepository.storeArticle(articleContent))));

--- a/src/server.ts
+++ b/src/server.ts
@@ -25,6 +25,7 @@ if (config.repoType === 'Sqlite') {
 } else if (config.repoType === 'InMemory') {
   repositoryType = StoreType.InMemory;
 } else {
+  // eslint-disable-next-line no-console
   console.log(`Cannot find article repository type of ${config.repoType}`);
   exit(1);
 }
@@ -33,7 +34,6 @@ let articleRepository: ArticleRepository;
 let getEnhancedArticle: GetEnhancedArticle;
 createArticleRepository(repositoryType, config.repoConnection).then(async (repo: ArticleRepository) => {
   articleRepository = repo;
-  await loadXmlArticlesFromDirIntoStores(config.dataDir, articleRepository);
   getEnhancedArticle = createEnhancedArticleGetter(articleRepository, config.id);
   app.listen(3000, () => {
     // eslint-disable-next-line no-console
@@ -57,4 +57,9 @@ app.get('/article/:publisherId/:articleId/reviews', async (req, res) => {
   const { publisherId, articleId } = req.params;
   const doi = `${publisherId}/${articleId}`;
   res.send(basePage(generateReviewPage(await getEnhancedArticle(doi))));
+});
+
+app.get('/import', async (req, res) => {
+  await loadXmlArticlesFromDirIntoStores(config.dataDir, articleRepository);
+  res.send({ status: true, message: 'Import completed' });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -41,6 +41,10 @@ app.get('/article/:publisherId/:articleId/reviews', async (req, res) => {
 });
 
 app.get('/import', async (req, res) => {
-  await loadXmlArticlesFromDirIntoStores(config.dataDir, articleRepository);
-  res.send({ status: true, message: 'Import completed' });
+  const results = await loadXmlArticlesFromDirIntoStores(config.dataDir, articleRepository);
+  if (results.every((value) => value === true)) {
+    res.send({ status: true, message: 'Import completed' });
+  } else {
+    res.send({ status: false, message: 'Some files were not imported.' });
+  }
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,10 +11,10 @@ import { createArticleRepository, StoreType } from './model/create-article-repos
 const app = express();
 
 const config = {
-  id: process.env.EPP_REVIEWGROUP_ID ?? 'https://elifesciences.org',
-  name: process.env.EPP_REVIEWGROUP_NAME ?? 'eLife',
-  dataDir: process.env.EPP_ARTICLE_DIR_PATH ?? './data/10.1101',
-  databasePath: process.env.EPP_DATABASE_PATH ?? './data.db',
+  id: process.env.REVIEWGROUP_ID ?? 'https://elifesciences.org',
+  name: process.env.REVIEWGROUP_NAME ?? 'eLife',
+  dataDir: process.env.ARTICLE_DIR_PATH ?? './data/10.1101',
+  databasePath: process.env.DATABASE_PATH ?? './data.db',
 };
 
 let articleRepository: ArticleRepository;

--- a/src/server.ts
+++ b/src/server.ts
@@ -45,6 +45,6 @@ app.get('/import', async (req, res) => {
   if (results.every((value) => value === true)) {
     res.send({ status: true, message: 'Import completed' });
   } else {
-    res.send({ status: false, message: 'Some files were not imported.' });
+    res.status(500).send({ status: false, message: 'Some files were not imported.' });
   }
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,10 +11,10 @@ import { createArticleRepository, StoreType } from './model/create-article-repos
 const app = express();
 
 const config = {
-  id: 'https://elifesciences.org',
-  name: 'eLife',
-  dataDir: './data/10.1101',
-  databasePath: './data.db',
+  id: process.env.EPP_REVIEWGROUP_ID ?? 'https://elifesciences.org',
+  name: process.env.EPP_REVIEWGROUP_NAME ?? 'eLife',
+  dataDir: process.env.EPP_ARTICLE_DIR_PATH ?? './data/10.1101',
+  databasePath: process.env.EPP_DATABASE_PATH ?? './data.db',
 };
 
 let articleRepository: ArticleRepository;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,4 @@
 import express from 'express';
-import { exit } from 'process';
 import { generateArticleList } from './article-list/article-list';
 import { articlePage } from './article/article-page';
 import { generateReviewPage } from './reviews/reviews';
@@ -7,32 +6,14 @@ import { basePage } from './base-page/base-page';
 import { ArticleRepository } from './model/model';
 import { loadXmlArticlesFromDirIntoStores } from './data-loader/data-loader';
 import { createEnhancedArticleGetter, GetEnhancedArticle } from './reviews/get-enhanced-article';
-import { createArticleRepository, StoreType } from './model/create-article-repository';
+import { createArticleRepository } from './model/create-article-repository';
+import { config } from './config';
 
 const app = express();
 
-const config = {
-  id: process.env.REVIEWGROUP_ID ?? 'https://elifesciences.org',
-  name: process.env.REVIEWGROUP_NAME ?? 'eLife',
-  dataDir: process.env.IMPORT_DIR_PATH ?? './data/10.1101',
-  repoType: process.env.REPO_TYPE ?? 'Sqlite',
-  repoConnection: process.env.REPO_CONNECTION ?? './data.db',
-};
-
-let repositoryType: StoreType;
-if (config.repoType === 'Sqlite') {
-  repositoryType = StoreType.Sqlite;
-} else if (config.repoType === 'InMemory') {
-  repositoryType = StoreType.InMemory;
-} else {
-  // eslint-disable-next-line no-console
-  console.log(`Cannot find article repository type of ${config.repoType}`);
-  exit(1);
-}
-
 let articleRepository: ArticleRepository;
 let getEnhancedArticle: GetEnhancedArticle;
-createArticleRepository(repositoryType, config.repoConnection).then(async (repo: ArticleRepository) => {
+createArticleRepository(config.repoType, config.repoConnection).then(async (repo: ArticleRepository) => {
   articleRepository = repo;
   getEnhancedArticle = createEnhancedArticleGetter(articleRepository, config.id);
   app.listen(3000, () => {


### PR DESCRIPTION
Change config to be set-able via ENV vars.

Also make import not automatic no we have a semi-permanent backing store, but allow remotely triggering import.

This will allow us to remove the articles from the repo, by attaching them in the kubernetes deployment