### PR TITLE
Don't sent status 500 when calling import and all files are already imported.

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -40,12 +40,18 @@ app.get('/article/:publisherId/:articleId/reviews', async (req, res) => {
   res.send(basePage(generateReviewPage(await getEnhancedArticle(doi))));
 });
 
+
+app.get('/import', async (req, res) => {
+  res.send(basePage(`<form method="POST">
+    <input type="submit" value="import">
+  </form>`));
+});
 app.post('/import', async (req, res) => {
   const results = await loadXmlArticlesFromDirIntoStores(config.dataDir, articleRepository);
   if (results.every((value) => value === true)) {
     res.send({ status: true, message: 'Import completed' });
   } else if (results.every((value) => value === false)) {
-    res.status(500).send({ status: false, message: 'No new files were imported' });
+    res.send({ status: false, message: 'No new files were imported' });
   } else {
     res.send({ status: true, message: 'Some new items imported' });
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -44,7 +44,9 @@ app.post('/import', async (req, res) => {
   const results = await loadXmlArticlesFromDirIntoStores(config.dataDir, articleRepository);
   if (results.every((value) => value === true)) {
     res.send({ status: true, message: 'Import completed' });
+  } else if (results.every((value) => value === false)) {
+    res.status(500).send({ status: false, message: 'No new files were imported' });
   } else {
-    res.status(500).send({ status: false, message: 'Some files were not imported.' });
+    res.send({ status: true, message: 'Some new items imported' });
   }
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -40,7 +40,6 @@ app.get('/article/:publisherId/:articleId/reviews', async (req, res) => {
   res.send(basePage(generateReviewPage(await getEnhancedArticle(doi))));
 });
 
-
 app.get('/import', async (req, res) => {
   res.send(basePage(`<form method="POST">
     <input type="submit" value="import">


### PR DESCRIPTION
Clients (such as that exhibit retry behaviour) will end up in a loop if they have no new files to import, but think they need to retry a webhook. Always return 200, just give details on what happened.

Also, add a GET on /import that allows a dev to trigger import manually easier than relying on curl or similar.