### PR TITLE
Add docker-compose config, with profiles for sqlite and couchdb

### DIFF
--- a/.docker/litestream.cfg
+++ b/.docker/litestream.cfg
@@ -1,0 +1,5 @@
+dbs:
+  - path: /opt/epp-data/data.db
+    replicas:
+      - url: s3://epp/data.db
+        endpoint: http://minio:9000

--- a/.docker/litestream.cfg
+++ b/.docker/litestream.cfg
@@ -1,5 +1,0 @@
-dbs:
-  - path: /opt/epp-data/data.db
-    replicas:
-      - url: s3://epp/data.db
-        endpoint: http://minio:9000

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: watch stop
+.PHONY: watch watch-couchdb watch-sqlite stop
 
 # Install Node.js dependencies if either, the node_modules directory is not present or package.json has changed.
 node_modules: package.json
@@ -12,6 +12,12 @@ public/styles.css: node_modules $(shell find src/**/*.scss -type f)
 watch: node_modules public/styles.css
 	@docker build . --target prod -t epp-watch
 	@docker run -d --rm --name epp-watch -p 8080:3000 -v $(CURDIR)/src:/opt/epp/src:rw epp-watch /opt/epp/scripts/watch.sh
+
+watch-couchdb: node_modules public/styles.css
+	@docker-compose --profile couchdb up
+
+watch-sqlite: node_modules public/styles.css
+	@docker-compose --profile sqlite up
 
 stop:
 	@-docker stop epp-watch

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ We currently have two supported databases:
 - SQLite
 - CouchDB
 
-Both databases can be brought up locally using docker-compose v2 and above. NOTE: docker-compose v1 is not supported.
+Both databases can be brought up locally using docker-compose.
 
 ## Running with SQLite
 

--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ Both databases can be brought up locally using docker-compose.
 
 ## Running with SQLite
 
-run `docker-compose --profile sqlite up -d` to bring up the application and all related services.
+run either `make watch-sqlite` or `docker-compose --profile sqlite up -d` to bring up the application and all related services.
 You can then import articles as described above.
 
 NOTE: You will need to run `docker-compose --profile sqlite down --volumes` to fully remove data after the service has shutdown.
 
 ## Running with CouchDB
 
-run `docker-compose --profile couchdb up -d` to bring up the application and all related services.
+run either `make watch-couchdb` or `docker-compose --profile couchdb up -d` to bring up the application and all related services.
 You can then import articles as described above.
 
 NOTE: You will need to run `docker-compose --profile couchdb down --volumes` to fully remove data after the service has shutdown.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,34 @@ make watch
 
 This will build and run the application on port `8080` and will rebuild any `ts` and `scss` files when they change.
 
+## Import example articles
+
+You will need to import some test articles from the repo into your instance. Visit http://localhost:8080/import and click import.
+
+## Running with databases
+
+We currently have two supported databases:
+- SQLite
+- CouchDB
+
+Both databases can be brought up locally using docker-compose.
+
+## Running with SQLite
+
+run `docker-compose --profile sqlite up -d` to bring up the application and all related services.
+You can then import articles as described above.
+
+NOTE: You will need to run `docker-compose --profile sqlite down --volumes` to fully remove data after the service has shutdown.
+
+## Running with CouchDB
+
+run `docker-compose --profile couchdb up -d` to bring up the application and all related services.
+You can then import articles as described above.
+
+NOTE: You will need to run `docker-compose --profile couchdb down --volumes` to fully remove data after the service has shutdown.
+
 ## Testing
-To test the application run: 
+To test the application run:
 ```shell
 yarn test
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ We currently have two supported databases:
 - SQLite
 - CouchDB
 
-Both databases can be brought up locally using docker-compose.
+Both databases can be brought up locally using docker-compose v2 and above. NOTE: docker-compose v1 is not supported.
 
 ## Running with SQLite
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -53,4 +53,3 @@ services:
 volumes:
   epp-data:
   couchdb:
-  minio:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,37 +13,6 @@ services:
     volumes:
     - ./src:/opt/epp/src
     - epp-data:/opt/epp-data
-  litestream:
-    profiles:
-    - sqlite
-    image: litestream/litestream
-    command: replicate -config /opt/litestream.cfg
-    environment:
-      AWS_ACCESS_KEY_ID: admin
-      AWS_SECRET_ACCESS_KEY: testtest
-    volumes:
-    - epp-data:/opt/epp-data
-    - ./.docker/litestream.cfg:/opt/litestream.cfg
-  minio:
-    profiles:
-    - sqlite
-    image: minio/minio
-    command: server /data --console-address ":9001"
-    environment:
-      MINIO_ROOT_USER: admin
-      MINIO_ROOT_PASSWORD: testtest
-    ports:
-    - "9000:9000"
-    - "9001:9001"
-    volumes:
-    - minio:/data
-  create-bucket:
-    profiles:
-    - sqlite
-    image: minio/mc
-    command: mb local/epp
-    environment:
-      MC_HOST_local: http://admin:testtest@minio:9000/
 
   # couchdb profile
   app-couchdb:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,85 @@
+services:
+  # SQLite profile
+  app-sqlite:
+    profiles:
+    - sqlite
+    build:
+      target: prod
+    command: yarn start:dev
+    environment:
+      REPO_CONNECTION: /opt/epp-data/data.db
+    ports:
+    - "8080:3000"
+    volumes:
+    - ./src:/opt/epp/src
+    - epp-data:/opt/epp-data
+  litestream:
+    profiles:
+    - sqlite
+    image: litestream/litestream
+    command: replicate -config /opt/litestream.cfg
+    environment:
+      AWS_ACCESS_KEY_ID: admin
+      AWS_SECRET_ACCESS_KEY: testtest
+    volumes:
+    - epp-data:/opt/epp-data
+    - ./.docker/litestream.cfg:/opt/litestream.cfg
+  minio:
+    profiles:
+    - sqlite
+    image: minio/minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: admin
+      MINIO_ROOT_PASSWORD: testtest
+    ports:
+    - "9000:9000"
+    - "9001:9001"
+    volumes:
+    - minio:/data
+  create-bucket:
+    profiles:
+    - sqlite
+    image: minio/mc
+    command: mb local/epp
+    environment:
+      MC_HOST_local: http://admin:testtest@minio:9000/
+
+  # couchdb profile
+  app-couchdb:
+    profiles:
+    - couchdb
+    build:
+      target: prod
+    command: yarn start:dev
+    environment:
+      REPO_TYPE: CouchDB
+      REPO_CONNECTION: http://couchdb:5984/
+      REPO_USERNAME: admin
+      REPO_PASSWORD: testtest
+    ports:
+    - "8080:3000"
+    volumes:
+    - ./src:/opt/epp/src
+    - epp-data:/opt/epp-data
+  couchdb:
+    profiles:
+    - couchdb
+    image: couchdb
+    environment:
+      COUCHDB_USER: admin
+      COUCHDB_PASSWORD: testtest
+    ports:
+    - "5984:5984"
+    volumes:
+    - couchdb:/home/couchdb/data
+  create-database:
+    profiles:
+    - couchdb
+    image: curlimages/curl
+    entrypoint: sh
+    command: -c 'sleep 5; curl -X PUT -u admin:testtest http://couchdb:5984/epp'
+volumes:
+  epp-data:
+  couchdb:
+  minio:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,7 @@ services:
     profiles:
     - sqlite
     build:
+      context: .
       target: prod
     command: yarn start:dev
     environment:
@@ -19,6 +20,7 @@ services:
     profiles:
     - couchdb
     build:
+      context: .
       target: prod
     command: yarn start:dev
     environment:

--- a/src/model/couchdb/couchdb-repository.ts
+++ b/src/model/couchdb/couchdb-repository.ts
@@ -88,7 +88,7 @@ export const createCouchDBArticleRepository = async (connectionString: string, u
       },
     },
   });
-  await couchServer.use('epp').head('_design/article-summaries', async (error, _, headers) => {
+  await couchServer.use('epp').head('_design/article-summaries', async (error) => {
     if (error) {
       await couchServer.use('epp').insert(
         {
@@ -101,7 +101,7 @@ export const createCouchDBArticleRepository = async (connectionString: string, u
         },
       );
     }
-  })
+  });
   const connection = couchServer.use<ArticleDocument>('epp');
   return new CouchDBArticleRepository(connection);
 };


### PR DESCRIPTION
Added documentation, ~but not added Makefile targets (yet).~ Will added make targets

This should bring up either a CouchDB, or SQLite ~+ minio (s3) replicated app locally,~ fully configured and setup.

The data will persist between `docker-compose up` runs (via docker anonymous volumes) and instructions for deleting volumes is included. 