### PR TITLE
fix(docker): Use yarn committed to repo when building docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 node_modules/**
-.yarn/**
+.yarn/cache/**
+.yarn/install-state.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add git python3 make gcc musl-dev g++
 COPY package.json package.json
 COPY yarn.lock yarn.lock
 COPY .yarnrc.yml .yarnrc.yml
-COPY .yarn .yarn
+COPY .yarn/releases .yarn/releases
 
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 RUN yarn

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /opt/epp
 
 FROM base as build
 
-# install latest yarn
+# install packages needed to build node_modules
 RUN apk add git python3 make gcc musl-dev g++
 
 COPY package.json package.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,13 @@ WORKDIR /opt/epp
 
 FROM base as build
 
+# install latest yarn
+RUN apk add git python3 make gcc musl-dev g++
+
 COPY package.json package.json
 COPY yarn.lock yarn.lock
+COPY .yarnrc.yml .yarnrc.yml
+COPY .yarn .yarn
 
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 RUN yarn


### PR DESCRIPTION
We're currently building the docker image with the default yarn (v1) which does not obey the yarn.lock file.

Another consequence of this was a broken docker image that does not work on the older version of alpine we were using. 

Both these issues are fixed with these changes.

- add .yarnrc and .yarn/releases/** to build image (alter .dockerignore to allow this)
- add packages required for a successful build of deps with yarn