### PR TITLE
Add some packagerules to automerge low-risk dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
fixes #236 .

This should reduce the number of manual interventions to major updates, with minor and patch and docker digest updates automerged once tests pass.