### PR TITLE
Fix CouchDB repo storing too many fields

### DIFF
--- a/src/model/couchdb/couchdb-repository.ts
+++ b/src/model/couchdb/couchdb-repository.ts
@@ -35,7 +35,14 @@ class CouchDBArticleRepository implements ArticleRepository {
   async storeArticle(article: ProcessedArticle): Promise<boolean> {
     const response = await this.documentScope.insert({
       _id: article.doi,
-      ...article,
+      title: article.title,
+      abstract: article.abstract,
+      authors: article.authors,
+      content: article.content,
+      date: article.date,
+      doi: article.doi,
+      headings: article.headings,
+      licenses: article.licenses,
     });
 
     if (!response.ok) {


### PR DESCRIPTION
We called object spread before storing the document in CouchDB. This
copied all the source fields rather than just those defined in the
target type, including the entire HTML document. We then separately
stored the HTML as an attachment.