### PR TITLE
Fix issue with HTML output by downgrading stencila schema

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,7 +6,7 @@
 export default {
 
   preset: 'ts-jest',
-  testEnvironment: 'jsdom',
+  testEnvironment: 'node',
   // All imported modules in your tests should be mocked automatically
   // automock: false,
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@stencila/encoda": "0.119.2",
-    "@stencila/schema": "1.18.0",
+    "@stencila/schema": "1.16.1",
     "axios": "0.27.2",
     "express": "4.18.1",
     "jsdom": "19.0.0",

--- a/src/article/article-flags.test.ts
+++ b/src/article/article-flags.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 import { screen } from '@testing-library/dom';
 import '@testing-library/jest-dom';
 import { generateFlags } from './article-flags';

--- a/src/article/header.test.ts
+++ b/src/article/header.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 import { within } from '@testing-library/dom';
 import '@testing-library/jest-dom';
 import { header } from './header';

--- a/src/article/jump-menu.test.ts
+++ b/src/article/jump-menu.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 import { screen } from '@testing-library/dom';
 import { Heading } from '../model/model';
 import { jumpToMenu } from './jump-menu';

--- a/src/data-loader/conversion/encode.test.ts
+++ b/src/data-loader/conversion/encode.test.ts
@@ -1,4 +1,5 @@
 import * as encoda from '@stencila/encoda';
+import { JSDOM } from 'jsdom';
 import { convertJatsToHtml } from './encode';
 
 describe('encode', () => {
@@ -18,6 +19,34 @@ describe('encode', () => {
           isBundle: true,
         },
       });
+      jest.restoreAllMocks();
+    });
+
+    it('converts JATS to HTML that contains an Abstract heading', async () => {
+      const html = await convertJatsToHtml('test-utils/jats-examples/example.xml');
+      const articleDom = JSDOM.fragment(html);
+      const abstractHeading = articleDom.querySelector('article > [data-itemprop="description"] > h2[data-itemtype="http://schema.stenci.la/Heading"]');
+      expect(abstractHeading).not.toBeNull();
+      expect(abstractHeading?.textContent).toBe('Abstract');
+    });
+
+    it('converts JATS to HTML with article body after the identifiers HTML', async () => {
+      const html = await convertJatsToHtml('test-utils/jats-examples/example.xml');
+      const articleDom = JSDOM.fragment(html);
+      const articleText = Array.from(articleDom.querySelectorAll('[data-itemprop="identifiers"] ~ *'))
+        .map((element) => element?.textContent ?? '')
+        .filter((line) => line.trim());
+
+      expect(articleText).toContain('Introduction');
+      expect(articleText).toContain('This is a simple article body');
+    });
+
+    it('converts JATS to HTML and expects headers to have a itemtype attribute', async () => {
+      const html = await convertJatsToHtml('test-utils/jats-examples/example.xml');
+      const articleDom = JSDOM.fragment(html);
+      const articleText = articleDom.querySelector('[itemtype="http://schema.stenci.la/Heading"]');
+
+      expect(articleText?.textContent).toBe('Introduction');
     });
   });
 });

--- a/test-utils/jats-examples/example.xml
+++ b/test-utils/jats-examples/example.xml
@@ -1,0 +1,124 @@
+<article article-type="article" specific-use="production" xml:lang="en" xmlns:hw="org.highwire.hpp"
+         xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:ref="http://schema.highwire.org/Reference"
+         xmlns:hwp="http://schema.highwire.org/Journal" xmlns:l="http://schema.highwire.org/Linking"
+         xmlns:r="http://schema.highwire.org/Revision" xmlns:x="http://www.w3.org/1999/xhtml"
+         xmlns:app="http://www.w3.org/2007/app" xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:nlm="http://schema.highwire.org/NLM/Journal" xmlns:a="http://www.w3.org/2005/Atom"
+         xmlns:c="http://schema.highwire.org/Compound" xmlns:hpp="http://schema.highwire.org/Publishing">
+    <front>
+        <journal-meta>
+            <journal-id journal-id-type="nlm-ta">elife</journal-id>
+            <journal-id journal-id-type="publisher-id">eLife</journal-id>
+            <journal-title-group>
+                <journal-title>eLife</journal-title>
+            </journal-title-group>
+            <publisher>
+                <publisher-name>eLife Sciences Publications, Ltd</publisher-name>
+            </publisher>
+        </journal-meta>
+        <article-meta>
+            <article-id pub-id-type="doi">10.7554/2022.08.09.123456</article-id>
+            <article-version>1.1</article-version>
+            <article-categories>
+                <subj-group subj-group-type="author-type">
+                    <subject>Regular Article</subject>
+                </subj-group>
+                <subj-group subj-group-type="heading">
+                    <subject>New Results</subject>
+                </subj-group>
+            </article-categories>
+            <title-group>
+                <article-title hwp:id="article-title-1">My test article</article-title>
+            </title-group>
+            <author-notes hwp:id="author-notes-1">
+                <corresp id="cor1" hwp:id="corresp-1" hwp:rev-id="xref-corresp-1-1"><label>*</label>Corresponding Author
+                    A. Reece Urcher. eLife Science Publications Ltd, Cambridge, United Kingdom.
+                </corresp>
+            </author-notes>
+            <contrib-group hwp:id="contrib-group-1">
+                <contrib contrib-type="author" corresp="yes" hwp:id="contrib-1">
+                    <name name-style="western" hwp:sortable="Urcher A. Reece">
+                        <surname>Urcher</surname>
+                        <given-names>A. Reece</given-names>
+                    </name>
+                    <xref ref-type="aff" rid="a1" hwp:id="xref-aff-1-1" hwp:rel-id="aff-1">1</xref>
+                    <xref ref-type="corresp" rid="cor1" hwp:id="xref-corresp-1-1" hwp:rel-id="corresp-1">*</xref>
+                </contrib>
+                <aff id="a1" hwp:id="aff-1" hwp:rev-id="xref-aff-1-1 xref-aff-1-2 xref-aff-1-3">
+                    <label>1</label>
+                    <institution hwp:id="institution-1">eLife Science Publications Ltd</institution>, Cambridge, <country>United Kingdom</country>
+                </aff>
+            </contrib-group>
+            <pub-date pub-type="epub-original" date-type="pub" publication-format="electronic" hwp:start="2022">
+                <year>2022</year>
+            </pub-date>
+            <pub-date pub-type="epub" hwp:start="2022-08-11T15:15:14-08:00">
+                <day>11</day>
+                <month>08</month>
+                <year>2022</year>
+            </pub-date>
+            <pub-date pub-type="epub-version" hwp:start="2022-08-11T15:15:14-08:00">
+                <day>11</day>
+                <month>08</month>
+                <year>2022</year>
+            </pub-date>
+            <elocation-id>2022.08.09.123456</elocation-id>
+            <history hwp:id="history-1">
+                <date date-type="received" hwp:start="2022-08-09">
+                    <day>09</day>
+                    <month>08</month>
+                    <year>2022</year>
+                </date>
+                <date date-type="rev-recd" hwp:start="2022-08-10">
+                    <day>10</day>
+                    <month>08</month>
+                    <year>2022</year>
+                </date>
+                <date date-type="accepted" hwp:start="2022-08-11">
+                    <day>11</day>
+                    <month>08</month>
+                    <year>2022</year>
+                </date>
+            </history>
+            <permissions>
+                <copyright-statement hwp:id="copyright-statement-1">© 2022, Posted by eLife Science Publications Ltd</copyright-statement>
+                <copyright-year>2022</copyright-year>
+                <license license-type="creative-commons" xlink:href="http://creativecommons.org/licenses/by/4.0/"
+                         hwp:id="license-1">
+                    <p hwp:id="p-1">This pre-print is available under a Creative Commons License (Attribution 4.0
+                        International), CC BY 4.0, as described at
+                        <ext-link l:rel="related" l:ref-type="uri" l:ref="http://creativecommons.org/licenses/by/4.0/"
+                                  ext-link-type="uri" xlink:href="http://creativecommons.org/licenses/by/4.0/"
+                                  hwp:id="ext-link-1">http://creativecommons.org/licenses/by/4.0/
+                        </ext-link>
+                    </p>
+                </license>
+            </permissions>
+            <self-uri xlink:href="469032.pdf" content-type="pdf" xlink:role="full-text"/>
+            <abstract hwp:id="abstract-1">
+                <title hwp:id="title-1">Abstract</title>
+                <p hwp:id="p-2">This is an abstract</p>
+            </abstract>
+            <kwd-group kwd-group-type="author" hwp:id="kwd-group-1">
+                <title hwp:id="title-2">Keywords</title>
+                <kwd hwp:id="kwd-1">Keyword</kwd>
+            </kwd-group>
+            <counts>
+                <page-count count="61"/>
+            </counts>
+        </article-meta>
+        <notes hwp:id="notes-1">
+            <notes notes-type="competing-interest-statement" hwp:id="notes-2">
+                <title hwp:id="title-3">Competing Interest Statement</title>
+                <p hwp:id="p-3">The authors have declared no competing interest.</p>
+            </notes>
+        </notes>
+    </front>
+    <body>
+        <sec id="s1" sec-type="intro">
+            <title>Introduction</title>
+            <p>This is a simple article body</p>
+        </sec>
+    </body>
+</article>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2447,7 +2447,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stencila/schema@npm:1.18.0, @stencila/schema@npm:^1.0.0":
+"@stencila/schema@npm:1.16.1":
+  version: 1.16.1
+  resolution: "@stencila/schema@npm:1.16.1"
+  checksum: d1a24d718d0ffbae30bd4ffdcb3f86925c0afd917c1258f183f238e08a8d54f5a9dded3cad62e6781976e9d0ce0a32420b5427aabb9b61397e0f416b029608ac
+  languageName: node
+  linkType: hard
+
+"@stencila/schema@npm:^1.0.0":
   version: 1.18.0
   resolution: "@stencila/schema@npm:1.18.0"
   checksum: 0e8dab776afd57c363d70749341d1f3a6ec75ec40a77b4e813ea2d40287a0ee857b6cedac7346c5cb211e84bcf0b4240384fbbce3cd54285fcc9706dff427f53
@@ -5817,7 +5824,7 @@ __metadata:
   resolution: "enhanced-preprints@workspace:."
   dependencies:
     "@stencila/encoda": 0.119.2
-    "@stencila/schema": 1.18.0
+    "@stencila/schema": 1.16.1
     "@testing-library/dom": 8.17.1
     "@testing-library/jest-dom": 5.16.5
     "@tsconfig/node16": 1.0.3


### PR DESCRIPTION
This evening, I noticed the HTML content has disappeared from the articles on EPP.

At first I thought it was something me or @will-byrne did (we did quite a bit of removing unused data from the databases), but it turns out to be a renovate-upgraded package from stencila.

It would be worth investigating the failure ~(and if we should add a test to pick it up)~ [added in a later commit], but to get the live system up and running, I've downgraded the package and tested that it restored functionality.